### PR TITLE
adds support to define a custom function for preconditionFailure

### DIFF
--- a/Sources/Hela/Precondition.swift
+++ b/Sources/Hela/Precondition.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+public struct Hela {
+    internal static var registry: TypeRegistry?
+
+    public static var isTesting: Bool {
+        ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
+    }
+
+    @discardableResult
+    public static func preconditionFailure<T>(_ message: @autoclosure () -> String = String(),
+                                              file: StaticString = #file,
+                                              line: UInt = #line) -> T {
+        guard isTesting, let registry = registry else {
+            Swift.preconditionFailure(message(), file: file, line: line)
+        }
+        do {
+            return try registry.get(type: T.self)
+        } catch {
+            fatalError("Error: \(error)")
+        }
+    }
+
+}

--- a/Sources/Hela/TypeKey.swift
+++ b/Sources/Hela/TypeKey.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+public struct TypeKey: Hashable {
+    public let type: Any.Type
+
+    init(type: Any.Type) {
+        self.type = type
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(ObjectIdentifier(type))
+    }
+
+    public static func ==(lhs: TypeKey, rhs: TypeKey) -> Bool {
+        lhs.type == rhs.type
+    }
+}

--- a/Sources/Hela/TypeRegistry.swift
+++ b/Sources/Hela/TypeRegistry.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+public typealias InstanceFactory = () -> Any
+
+public class TypeRegistry {
+    public enum Failure: Error {
+        case typeNotRegistered(Any.Type)
+    }
+
+    private var registry = [TypeKey: InstanceFactory]()
+
+    public func register<T>(type: T.Type, factory: @escaping () -> T) {
+        registry[TypeKey(type: type)] = factory
+    }
+
+    public func get<T>(type: T.Type) throws -> T {
+        guard let factory = registry[TypeKey(type: type)],
+        let instance = factory() as? T else {
+            throw Failure.typeNotRegistered(type)
+        }
+        return instance
+    }
+
+    public func reset() {
+        registry.removeAll()
+    }
+}


### PR DESCRIPTION
This custom function will support testing which won't depending on trapping the normal kill signal and will instead support returning a value which matches the return type while testing.